### PR TITLE
Changed feedforward() function to predict().

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This Project doesn't require any additional Installing steps
 ### Documentation
 
 * `NeuralNetwork` - The neural network class
-  * `feedforward(input_array)` - Returns the output of a neural network
+  * `predict(input_array)` - Returns the output of a neural network
   * `train(input_array, target_array)` - Trains a neural network
 
 ## Running the tests

--- a/examples/xor/sketch.js
+++ b/examples/xor/sketch.js
@@ -41,7 +41,7 @@ function draw() {
       let y = j * resolution;
       let input_1 = i / (cols - 1);
       let input_2 = j / (rows - 1);
-      let output = nn.feedforward([input_1, input_2]);
+      let output = nn.predict([input_1, input_2]);
       let col = output[0] * 255;
       fill(col);
       noStroke();

--- a/lib/nn.js
+++ b/lib/nn.js
@@ -36,7 +36,7 @@ class NeuralNetwork {
     this.learning_rate = 0.1;
   }
 
-  feedforward(input_array) {
+  predict(input_array) {
 
     // Generating the Hidden Outputs
     let inputs = Matrix.fromArray(input_array);


### PR DESCRIPTION
Related issue: [https://github.com/CodingTrain/Toy-Neural-Network-JS/issues/19](url)

Changed nn.feedforward() function to nn.predict().

