### PR TITLE
Made the matrix methods return the matrix, making them chainable, and added a test.

### DIFF
--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -50,6 +50,7 @@ class Matrix {
         this.data[i][j] = Math.random() * 2 - 1;
       }
     }
+    return this;
   }
 
   add(n) {
@@ -66,6 +67,7 @@ class Matrix {
         }
       }
     }
+    return this;
   }
 
   static transpose(matrix) {
@@ -114,6 +116,7 @@ class Matrix {
         }
       }
     }
+    return this;
   }
 
   map(func) {
@@ -124,6 +127,7 @@ class Matrix {
         this.data[i][j] = func(val);
       }
     }
+    return this;
   }
 
   static map(matrix, func) {
@@ -140,6 +144,7 @@ class Matrix {
 
   print() {
     console.table(this.data);
+    return this;
   }
 }
 

--- a/lib/matrix.test.js
+++ b/lib/matrix.test.js
@@ -162,26 +162,26 @@ test('mapping with instance map', () => {
 
 test('error handling of matrix product when columns of A don\'t match rows of B.', () => {
   //Replace console.log with a jest mock so we can see if it has been called
-  global.console.log = jest.fn(); 
+  global.console.log = jest.fn();
 
   let m1 = new Matrix(1, 2);
   let m2 = new Matrix(3, 4);
   Matrix.multiply(m1, m2);
 
   //Check if the mock console.log has been called 
-  expect(global.console.log).toHaveBeenCalledWith('Columns of A must match rows of B.') 
+  expect(global.console.log).toHaveBeenCalledWith('Columns of A must match rows of B.')
 });
 
 test('printing', () => {
   //Replace console.table with a jest mock so we can see if it has been called
-  global.console.table = jest.fn(); 
+  global.console.table = jest.fn();
 
   let m1 = new Matrix(2, 3);
   m1.randomize();
   m1.print();
 
   //Check if the mock console.table has been called 
-  expect(global.console.table).toHaveBeenCalledWith(m1.data) 
+  expect(global.console.table).toHaveBeenCalledWith(m1.data)
 });
 
 test('matrix from array', () => {
@@ -206,4 +206,23 @@ test('matrix to array', () => {
 
   let array = m.toArray();
   expect(array).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+});
+
+test('chanining matrix methods', () => {
+  let m = new Matrix(3, 3);
+  m.data[0] = [1, 2, 3];
+  m.data[1] = [4, 5, 6];
+  m.data[2] = [7, 8, 9];
+
+  m.map(e => e - 1).multiply(10).add(6).print();
+
+  expect(m).toEqual({
+    rows: 3,
+    cols: 3,
+    data: [
+      [6, 16, 26],
+      [36, 46, 56],
+      [66, 76, 86]
+    ]
+  });
 });


### PR DESCRIPTION
This commit allows stuff like `m.add(x)multiply(y).print()` possible, as well as for example `return m.map(e => e*2)` which will simplify some stuff later down the road. 
_The test I added does not cover all the functions so some additions may be needed._