### PR TITLE
Add links to demos running in GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,18 @@
 
 Neural Network JavaScript library for Coding Train tutorials
 
+## Examples / Demos
+Here are some demos running directly in the browser:
+[XOR problem](https://codingtrain.github.io/Toy-Neural-Network-JS/examples/xor/)
+[Handwritten digit recognition](https://codingtrain.github.io/Toy-Neural-Network-JS/examples/mnist/)
+
 ## To-Do List
 
 * [x] Redo gradient descent video about
 * [x] Delta weight formulas, connect to "mathematics of gradient" video
 * [x] Implement gradient descent in library / with code
-* [x] XOR coding challenge
-* [x] MNIST coding challenge
+* [x] XOR coding challenge [live example](https://codingtrain.github.io/Toy-Neural-Network-JS/examples/xor/)
+* [x] MNIST coding challenge [live example](https://codingtrain.github.io/Toy-Neural-Network-JS/examples/mnist/)
 * [ ] Support for saving / restoring network (see #50)
 * [ ] Support for different activation functions (see #45)
 * [ ] softmax activation, cross-entropy

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Neural Network JavaScript library for Coding Train tutorials
 
 ## Examples / Demos
 Here are some demos running directly in the browser:
-[XOR problem](https://codingtrain.github.io/Toy-Neural-Network-JS/examples/xor/)
-[Handwritten digit recognition](https://codingtrain.github.io/Toy-Neural-Network-JS/examples/mnist/)
+* [XOR problem](https://codingtrain.github.io/Toy-Neural-Network-JS/examples/xor/)
+* [Handwritten digit recognition](https://codingtrain.github.io/Toy-Neural-Network-JS/examples/mnist/)
 
 ## To-Do List
 


### PR DESCRIPTION
This fixes #52 by adding links to the two examples live running in the browser using
GitHub Pages (https://codingtrain.github.io/Toy-Neural-Network-JS).

* [XOR problem](https://codingtrain.github.io/Toy-Neural-Network-JS/examples/xor/)
* [Handwritten digit recognition](https://codingtrain.github.io/Toy-Neural-Network-JS/examples/mnist/)