### PR TITLE
Fixed (de)serialization to include activation function.

### DIFF
--- a/lib/nn.js
+++ b/lib/nn.js
@@ -5,6 +5,13 @@ class ActivationFunction {
     this.func = func;
     this.dfunc = dfunc;
   }
+
+  static deserialize(data) {
+    if (typeof data == 'string') {
+      data = JSON.parse(data);
+    }
+    return new ActivationFunction(eval(data.func), eval(data.dfunc));
+  }
 }
 
 let sigmoid = new ActivationFunction(
@@ -139,7 +146,7 @@ class NeuralNetwork {
   }
 
   serialize() {
-    return JSON.stringify(this);
+    return JSON.stringify(this, (k, v) => typeof v == 'function' ? v.toString() : v);
   }
 
   static deserialize(data) {
@@ -152,6 +159,7 @@ class NeuralNetwork {
     nn.bias_h = Matrix.deserialize(data.bias_h);
     nn.bias_o = Matrix.deserialize(data.bias_o);
     nn.learning_rate = data.learning_rate;
+    nn.activation_function = ActivationFunction.deserialize(data.activation_function);
     return nn;
   }
 


### PR DESCRIPTION
This fixes #96 by using a `replacer` on serialization to preserve the activation function as a string.
On deserialization the function string is `eval()`-ed. This is dangerous as malicious code could be
executed. Might be possible to port this to using `new Function()` instead.