### PR TITLE
Add Matrix copy() test

### DIFF
--- a/lib/matrix.test.js
+++ b/lib/matrix.test.js
@@ -363,11 +363,25 @@ test('static map with row and column params', () => {
     ]
   });
 });
+
 test('matrix (de)serialization', () => {
   let m = new Matrix(5, 5);
   m.randomize();
 
   let n = Matrix.deserialize(m.serialize());
+
+  expect(n).toEqual({
+    rows: m.rows,
+    cols: m.cols,
+    data: m.data
+  });
+});
+
+test('matrix copy', () => {
+  let m = new Matrix(5, 5);
+  m.randomize();
+
+  let n = m.copy();
 
   expect(n).toEqual({
     rows: m.rows,


### PR DESCRIPTION
This adds a test for the `Matrix.copy()` function.