### PR TITLE
Adding crossover function

### DIFF
--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -18,6 +18,12 @@ class Matrix {
     return m;
   }
 
+  static crossover(a, b, ratio = 0.5) {
+    let m = a.copy();
+    m.map((value, i, j) => Math.random() < ratio ? value : b.data[i][j])
+    return m;
+  }
+
   static fromArray(arr) {
     return new Matrix(arr.length, 1).map((e, i) => arr[i]);
   }

--- a/lib/nn.js
+++ b/lib/nn.js
@@ -175,6 +175,14 @@ class NeuralNetwork {
     this.bias_o.map(mutate);
   }
 
+  static crossover(a, b, ratio = 0.5) {
+    let nn = a.copy();
+    nn.weights_ih = Matrix.crossover(a.weights_ih, b.weights_ih, ratio);
+    nn.weights_ho = Matrix.crossover(a.weights_ho, b.weights_ho, ratio);
+    nn.bias_h = Matrix.crossover(a.bias_h, b.bias_h, ratio);
+    nn.bias_o = Matrix.crossover(a.bias_o, b.bias_o, ratio);
+    return nn;
+  }
 
 
 }


### PR DESCRIPTION
This commit adds crossover functions to the Matrix and NeuralNetwork class. It defaults
to a uniform crossover (ratio = 0.5), but this is customizable (third parameter).

You can use it as such:
```javascript
let mom = new NeuralNetwork(2, 4, 1);
let dad = new NeuralNetwork(2, 4, 1);
let child = NeuralNetwork.crossover(mom, dad);
```