### PR TITLE
Added another Library reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Please send PullRequests. These need to pass a automated Test first and after it
 Here are some libraries with the same or similar functionality to this one built by the community:
 
 - [Java Neural Network Library](https://github.com/kim-marcel/basic_neural_network) by [kim-marcel](https://github.com/kim-marcel)
+- [Library-less Java Neural Network](https://github.com/Fir3will/Java-Neural-Network) by [Fir3will](https://github.com/Fir3will)
 - [Python Neural Network Library](https://github.com/Gabriel-Teston/Machine-Learning) by [Gabriel-Teston](https://github.com/Gabriel-Teston)
 
 Feel free to add your own libraries.


### PR DESCRIPTION
I've created another Java Neural Network library that requires no extra libraries like the other Java one did. The Matrix class is similar to yours and completely documented. I haven't added documentation to the NeuralNetwork class but that is next on my list