### PR TITLE
Add pipe's width when bird is looking for closest pipe

### DIFF
--- a/examples/neuroevolution-flappybird/bird.js
+++ b/examples/neuroevolution-flappybird/bird.js
@@ -62,7 +62,7 @@ class Bird {
     let closest = null;
     let record = Infinity;
     for (let i = 0; i < pipes.length; i++) {
-      let diff = pipes[i].x - this.x;
+      let diff = pipes[i].x - this.x + pipes[i].w;
       if (diff > 0 && diff < record) {
         record = diff;
         closest = pipes[i];


### PR DESCRIPTION
The pipe's width should be added when looking for nearest pipe.
Without this fix, then the bird might go up too early and die.